### PR TITLE
`Device.start()` now raises an error if failed to start cameras and imu

### DIFF
--- a/pykinect_azure/k4a/device.py
+++ b/pykinect_azure/k4a/device.py
@@ -43,8 +43,11 @@ class Device:
 
 	def start(self, configuration, record=False, record_filepath="output.mkv"):
 		self.configuration = configuration
-		self.start_cameras(configuration)
-		self.start_imu()
+		try:
+			self.start_cameras(configuration)
+			self.start_imu()
+		except Exception as e:
+			raise e
 
 		if record:
 			self.record = Record(self._handle, self.configuration.handle(), record_filepath)


### PR DESCRIPTION
Wraps a try-catch statement around starting cameras and IMU, and throws the Exception forward if one occurs